### PR TITLE
Fixing style path issue and reallowing arbitrary content in tree.

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -12,7 +12,7 @@
   /// -> auto | content
   content: auto,
   /// Subchapters
-  /// -> any | chatper
+  /// -> any | chapter
   children: (),
   /// Extra arguments passed to the renderer
   /// -> any
@@ -52,8 +52,8 @@
 }
 
 #let normalize-tree(tree, root) = {
-  let new-tree = ()
-  for it in tree {
+  assert(type(tree) == array, message: "The tree argument must be an array. Maybe you forgot a comma?")
+  tree.map(it => {
     if type(it) != dictionary or "kind" not in it {
       it = (
         kind: "other",
@@ -91,9 +91,8 @@
     if "children" in it {
       it = (..it, children: normalize-tree(it.children, root))
     }
-    new-tree.push(it)
-  }
-  new-tree
+    it
+  })
 }
 
 #import "new-hamber.typ": html-renderer, paged-renderer
@@ -120,7 +119,7 @@
   /// The authors of the documentation. It should be an array of strings.
   /// -> array
   authors: (),
-  /// The root of the site. Set this when you are not deploying the docuemtation
+  /// The root of the site. Set this when you are not deploying the documentation
   /// to the root of your website, instead you're deploying it to a subfolder.
   /// E.g., when deploying to GitHub Pages.
   /// -> str | array

--- a/new-hamber.typ
+++ b/new-hamber.typ
@@ -3,7 +3,7 @@
 #let summary-renderer(current-tree, current-chapter) = for it in current-tree {
   html.div(
     class: "w-full relative"
-      + if it.page-label == current-chapter.page-label {
+      + if "page-label" in it and it.page-label == current-chapter.page-label {
         " bg-white border-y border-neutral-300 "
       } else {
         " hover:bg-neutral-200 "
@@ -23,17 +23,17 @@
         )
       }
       if it.children.len() > 0 {
-        input(
+        html.input(
           class: "absolute peer top-2 right-2 h-4 w-4",
           type: "checkbox",
           checked: true,
         )
       }
     } else {
-      div(class: "p-2", it.content)
+      html.div(class: "p-2", it.content)
     }
       + if "children" in it and it.children.len() > 0 {
-        div(
+        html.div(
           class: "ml-3 border-neutral-300 border-l border-b col-start-2 col-span-2 hidden peer-checked:block",
           summary-renderer(it.children, current-chapter),
         )
@@ -218,7 +218,7 @@
   // first generate the tailwind preflight
   let site-title = title
   import "@preview/typhoon:0.1.2"
-  let stylesheet-path = "/" + root.join("/") + "/styles.css"
+  let stylesheet-path = "/" + (root, "styles.css").flatten().join("/")
   let page-classes = state("__new_hamber page classes", "")
   asset(
     stylesheet-path,


### PR DESCRIPTION
Fixed some errors I encountered while trying it out:
- if no root was specified, `\\styles.css` would be the path written
- The example with `[= Introduction]` did no longer work
- added an assertion, for checking if tree is really of desired shape
- fixed some typos and a few missing html inclusion for html elements

On another branch I implemented some minor customization options, which could be added in another PR.