### PR TITLE
fix: update stale doc.typ references to dist.typ

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ has a single requirement: [Typst](https://github.com/typst/typst). Here are some
 
 ![Otter Docs with the default theme "New Hamber"](./demo.png)
 
-(See [doc.typ](./doc.typ) for a more comprehensive example)
+(See [dist.typ](./dist.typ) for a more comprehensive example)
 
 (See <https://wensimehrp.github.io/haita> for an online demo)
 

--- a/serve-doc
+++ b/serve-doc
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-typst watch --features bundle,html --format bundle ./doc.typ ./dist
+typst watch --features bundle,html --format bundle ./dist.typ ./dist


### PR DESCRIPTION
doc.typ was renamed to dist.typ in 7b2b018. 
But README.md and serve-doc still referenced the old name. Fixed both.