### PR TITLE
fix: make the code copy button work over http

### DIFF
--- a/new-hamber.typ
+++ b/new-hamber.typ
@@ -170,10 +170,27 @@
           " dark:border-transparent dark:bg-zinc-800 dark:text-neutral-300 dark:hover:bg-zinc-700"
         },
         onclick: ```js
-        navigator.clipboard.writeText(this.nextElementSibling.querySelector('code').textContent).then(() => {
-          this.textContent = 'Copied!'
+        const text = this.nextElementSibling.querySelector('code').textContent;
+        const done = () => {
+          this.textContent = 'Copied!';
           setTimeout(() => { this.textContent = 'Copy'; }, 2000);
-        })
+        };
+        if (navigator.clipboard) {
+          navigator.clipboard.writeText(text).then(done).catch(console.error);
+        } else {
+          const input = document.createElement('textarea');
+          input.value = text;
+          input.style.position = 'fixed';
+          input.style.top = '0';
+          input.style.left = '0';
+          input.style.opacity = '0';
+          input.setAttribute('readonly', '');
+          document.body.appendChild(input);
+          input.select();
+          document.execCommand('copy');
+          document.body.removeChild(input);
+          done();
+        }
         ```.text,
       ))[Copy]
       pre(code-fn(for line in it.lines {


### PR DESCRIPTION
`navigator.clipboard` is only available in secure contexts ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText)), so on plain-http sites the copy button currently doesn't copy anything.

This adds a fallback for non-secure contexts using a temporary `<textarea>` and `document.execCommand("copy")`, with the same "Copied!" feedback as the clipboard path. It follows the approach of the [official Typst docs](https://github.com/typst/typst/blob/89495172a5b6a697cbf2d6c560efb2da9dfd173b/docs/assets/docs.js#L1217-L1233), with small tweaks.