### PR TITLE
fix: rename `book`'s `language` parameter to `lang` to match the renderer

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -131,7 +131,7 @@
   root: (),
   /// The language of the documentation
   /// -> str
-  language: "en",
+  lang: "en",
   /// Which HTML renderer to use. By default it uses _New Hamber_'s html renderer.
   /// -> function
   html-renderer: (..args) => new-hamber.html-renderer.with(
@@ -170,7 +170,7 @@
     //   description: description,
     //   authors: authors,
     //   root: root,
-    //   language: language,
+    //   lang: lang,
     //   ..args,
     // )
   }
@@ -183,7 +183,7 @@
       render-summary-image: render-summary-image,
       authors: authors,
       root: root,
-      language: language,
+      lang: lang,
       ..args,
     )
   }


### PR DESCRIPTION
`book()` declares a `language` parameter, but `html-renderer` expects `lang` and its unused `..args` sink swallowed it silently, so passing `language` had no effect and every page was emitted as `<html lang="en">`.

After this change, `language` is still accepted without error, as it was before, and `lang` continues to work as it does today.