### PR TITLE
feat!: unify `canonical-url` and `root` into an optional `base-url`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./dist/haita
+          path: ./dist
   # Job 2: deploy the docs
   deploy:
     needs: build-docs

--- a/Justfile
+++ b/Justfile
@@ -10,7 +10,7 @@ build:
 
 # index the site
 index: build
-    pagefind --site ./dist --output-subdir haita/pagefind
+    pagefind --site ./dist --output-subdir pagefind
 
 # watch build output
 watch:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Haita with the default theme New Hamber](https://raw.githubusercontent.com/wensimehrp/haita/dd157623155bf755c3fe9b698b606b2ed2b9c3b7/demo.avif)
+![Haita with the default theme New Hamber](https://raw.githubusercontent.com/wensimehrp/haita/b24160ce08dbb336096585db2e8d7cc2a23cabc5/demo.avif)
 
 # Haita
 
@@ -53,18 +53,18 @@ when compiling the documents.
 ``` typ
 #import "@preview/haita:0.3.0": * // Always remember to import the package
 #book(
-  // The routing root. Useful when you are deploying to a folder
-  // under your root (e.g. when deployed to GitHub Pages)
-  // root: "haita",
+  // Where the site will be deployed. Optional: it is only used for the
+  // SEO metadata, everything inside the site is linked relatively.
+  // base-url: "https://username.github.io/haita",
   // Your document's contents
   tree: (
     // You can add arbitrary content. The content will be displayed
     // in the summary, but will not generate html pages.
     [= Introduction],
-    // This will create haita/index.html. The content of the
+    // This will create index.html. The content of the
     // chapter will be from `doc/intro.typ`
     chapter("index", content: include "doc/intro.typ"),
-    // This will create haita/doc/tutorial.html. In this case,
+    // This will create doc/tutorial.html. In this case,
     // the content of the chapter is not explicitly stated, so it
     // looks into ./doc/tutorial.typ in the current workspace.
     chapter("doc/tutorial"),

--- a/dist.typ
+++ b/dist.typ
@@ -11,13 +11,11 @@
 #book(
   debug: true,
   title: "Haita Docs Documentation",
-  canonical-url: "https://wensimehrp.github.io",
-  root: "haita",
+  base-url: "https://wensimehrp.github.io/haita",
   html-renderer: new-hamber.html-renderer.with(
     pagefind-enabled: true,
     summary-image-renderer: new-hamber.summary-image-renderer.with(
       "Haita",
-      "https://wensimehrp.github.io",
       bottom-content: [
         Haita is a pure Typst documentation framework
       ],

--- a/docs/installation.typ
+++ b/docs/installation.typ
@@ -8,4 +8,4 @@
 
 You can install Typst at #link("https://typst.app/open-source/#download").
 
-After you installed Typst, move to the #link(label("page:/haita/tutorial"))[next section] to get started using Haita.
+After you installed Typst, move to the #link(label("page:/tutorial"))[next section] to get started using Haita.

--- a/docs/tutorial/integration.typ
+++ b/docs/tutorial/integration.typ
@@ -87,15 +87,6 @@ The default theme _New Hamber_ provides built-in support for Pagefind.
   pagefind --site ./dist --output-subdir pagefind
   ```
 
-  If you changed the root of your site (i.e. you are deploying to a subdir), you need to change the command.
-
-  ```sh
-  # if your subdir is `haita`
-  pagefind --site ./dist --output-subdir haita/pagefind
-  # if your subdir is `foo/bar/baz`
-  pagefind --site ./dist --output-subdir foo/bar/baz/pagefind
-  ```
-
 After you finished all of that, you should be able to see a pagefind searchbox in your main table of contents at the
 left hand side.
 

--- a/fonts/fonts.typ
+++ b/fonts/fonts.typ
@@ -11,7 +11,7 @@
 
 #let (header, ..font-list) = csv("fontlist.csv")
 
-#let font-files(root) = font-list.map(((.., font-file)) => asset(root + "/fonts/" + font-file, read(
+#let font-files() = font-list.map(((.., font-file)) => asset("/fonts/" + font-file, read(
   font-file,
   encoding: none,
 )))

--- a/lib.typ
+++ b/lib.typ
@@ -56,7 +56,13 @@
   }
 }
 
-#let normalize-tree(tree, root) = {
+#let normalize-base-url(base-url) = {
+  if base-url == none { return none }
+  let base-url = base-url.trim("/", at: end, repeat: true)
+  if base-url.len() == 0 { none } else { base-url }
+}
+
+#let normalize-tree(tree) = {
   assert(type(tree) == array, message: "The tree argument must be an array. Maybe you forgot a comma?")
   tree.map(it => {
     if type(it) != dictionary or "kind" not in it {
@@ -67,7 +73,6 @@
     }
     let path-str = none
     if "path" in it {
-      it.path = root + it.path
       path-str = it.path.join("/")
       it.insert("page-label", label("page:/" + path-str))
     }
@@ -94,7 +99,7 @@
       it.insert("headings", chapter-heading-state.final())
     }
     if "children" in it {
-      it = (..it, children: normalize-tree(it.children, root))
+      it = (..it, children: normalize-tree(it.children))
     }
     it
   })
@@ -111,11 +116,15 @@
   /// The description of the documentation.
   /// -> str
   description: "",
-  /// The canonical URL of the documentation, e.g. the site's domain when you
-  /// deploy the documentation to a website. Examples include `<username>.github.io`
-  /// for GitHub Pages and `<project name>.pages.dev` for Cloudflare Pages.
-  /// -> str
-  canonical-url: "",
+  /// The URL the documentation is deployed at, including the subfolder when you
+  /// are not deploying to the root of a site. Examples include
+  /// `https://<username>.github.io/<project name>` for GitHub Pages and
+  /// `https://<project name>.pages.dev` for Cloudflare Pages.
+  ///
+  /// This setting is optional: it is only used to build the absolute URLs
+  /// that SEO metadata requires (the canonical link, Open Graph and Twitter cards).
+  /// -> none | str
+  base-url: none,
   /// Whether or not to render the summary images. Summary images are displayed
   /// when pasting pages' link in various social media, such as Telegram, Discord,
   /// and X.
@@ -124,11 +133,6 @@
   /// The authors of the documentation. It should be an array of strings.
   /// -> array
   authors: (),
-  /// The root of the site. Set this when you are not deploying the documentation
-  /// to the root of your website, instead you're deploying it to a subfolder.
-  /// E.g., when deploying to GitHub Pages.
-  /// -> str | array
-  root: (),
   /// The language of the documentation
   /// -> str
   lang: "en",
@@ -136,10 +140,7 @@
   /// -> function
   html-renderer: (..args) => new-hamber.html-renderer.with(
     summary-image-renderer: if args.named().render-summary-image {
-      new-hamber.summary-image-renderer.with(
-        args.named().title,
-        args.named().canonical-url,
-      )
+      new-hamber.summary-image-renderer.with(args.named().title)
     } else {
       none
     },
@@ -158,18 +159,17 @@
   /// -> any
   ..args,
 ) = context {
-  let root = if type(root) == array { root } else { root.split("/").filter(it => it.len() > 0) }
+  let base-url = normalize-base-url(base-url)
   assert(type(authors) == array, message: "Authors must be an array of strings.")
-  let normalized = normalize-tree(tree, root)
+  let normalized = normalize-tree(tree)
   // debug for testing the tree
-  if debug { document(root.join("/") + "/__debug_tree.html", [#normalized]) }
+  if debug { document("/__debug_tree.html", [#normalized]) }
   if target() in ("paged",) {
     panic("Paged export is suspended until https://github.com/typst/typst/issues/7998 is resolved")
     // paged-renderer(
     //   normalized,
     //   description: description,
     //   authors: authors,
-    //   root: root,
     //   lang: lang,
     //   ..args,
     // )
@@ -179,10 +179,9 @@
       normalized,
       title: title,
       description: description,
-      canonical-url: canonical-url,
+      base-url: base-url,
       render-summary-image: render-summary-image,
       authors: authors,
-      root: root,
       lang: lang,
       ..args,
     )
@@ -195,7 +194,6 @@
 /// #book(
 ///   html-renderer: new-hamber.html-renderer.with(
 ///     summary-image-renderer: lib.minimal-summary-image-renderer.with(
-///       <your-url-here>, // place your canonical url here. MANDATORY FIELD
 ///       image-content: it => [...] // your content here
 ///       // Don't complete any other fields
 ///     )
@@ -203,13 +201,16 @@
 /// )
 /// ```
 #let minimal-summary-image-renderer(
-  /// The canonical URL of your site. This is completed by the user
-  /// -> str
-  canonical-url,
   /// The chapter that would be feeded into the renderer.
   /// #highlight[Usually this is internal to the renderer, and should not be completed.]
   /// -> chapter
   chapter,
+  /// The base URL of your site, taken from `book`'s `base-url`.
+  /// #highlight[Usually this is internal to the renderer, and should not be completed.]
+  /// When it is `none` the image is referenced relative to the page instead of
+  /// by an absolute URL.
+  /// -> none | str
+  base-url: none,
   /// The width of the image in pixels. For the default PPI it is 1pt -> 1px.
   /// -> int
   width-px: 1200,
@@ -225,6 +226,7 @@
   image-content: chapter => none,
 ) = {
   let image-path = "/" + chapter.path.join("/") + "_summary.png"
+  let image-url = if base-url == none { chapter.path.last() + "_summary.png" } else { base-url + image-path }
   (
     document: document(
       image-path,
@@ -235,12 +237,12 @@
       ),
     ),
     og-properties: {
-      html.elem("meta", attrs: (property: "og:image", content: canonical-url + image-path))
+      html.elem("meta", attrs: (property: "og:image", content: image-url))
       html.elem("meta", attrs: (property: "og:image:type", content: "image/png"))
       html.elem("meta", attrs: (property: "og:image:width", content: str(width-px)))
       html.elem("meta", attrs: (property: "og:image:height", content: str(height-px)))
       html.meta(name: "twitter:card", content: "summary_large_image")
-      html.meta(name: "twitter:image", content: canonical-url + image-path)
+      html.meta(name: "twitter:image", content: image-url)
     },
   )
 }

--- a/new-hamber.typ
+++ b/new-hamber.typ
@@ -344,8 +344,8 @@
 
 #let summary-image-renderer(
   site-title,
-  canonical-url,
   chapter,
+  base-url: none,
   bottom-content: none,
   // defaults to 1pt -> 1px
   width-px: 1200,
@@ -353,6 +353,7 @@
   ppi: 144,
 ) = {
   let image-path = "/" + chapter.path.join("/") + "_summary.png"
+  let image-url = if base-url == none { chapter.path.last() + "_summary.png" } else { base-url + image-path }
   (
     document: document(
       image-path,
@@ -369,12 +370,12 @@
       ],
     ),
     og-properties: {
-      og-property("image", content: canonical-url + image-path)
+      og-property("image", content: image-url)
       og-property("image:type", content: "image/png")
       og-property("image:width", content: str(width-px))
       og-property("image:height", content: str(height-px))
       html.meta(name: "twitter:card", content: "summary_large_image")
-      html.meta(name: "twitter:image", content: canonical-url + image-path)
+      html.meta(name: "twitter:image", content: image-url)
     },
   )
 }
@@ -382,9 +383,8 @@
 #let html-renderer(
   tree,
   lang: "en",
-  root: (),
   title: "",
-  canonical-url: "",
+  base-url: none,
   summary-image-renderer: none,
   footer-content: [
     Powered by #link("https://github.com/wensimehrp/haita")[Haita]. Made in Vancouver with love.
@@ -405,11 +405,10 @@
   let site-title = title
   import "@preview/typhoon:0.1.2"
   import "fonts/fonts.typ": font-css, font-files
-  let stylesheet-path = "/" + (root, "styles.css").flatten().join("/")
-  font-files(root.join("/")).join()
+  font-files().join()
   [
     #asset(
-      stylesheet-path,
+      "/styles.css",
       {
         read("styles/styles.css")
         str(typhoon._plugin.generate(bytes(page-classes.final().keys().join(" ", default: "")), cbor.encode((
@@ -438,7 +437,12 @@
     tree,
     chapter-generator: it => [
       #let page-path-str = "/" + it.path.join("/") + ".html"
-      #if type(summary-image-renderer) == function { summary-image-renderer(it).document }
+      #let page-url = if base-url != none { base-url + page-path-str }
+      #let up = ("..",) * (it.path.len() - 1)
+      #let summary-image = if type(summary-image-renderer) == function {
+        summary-image-renderer(it, base-url: base-url)
+      }
+      #if summary-image != none { summary-image.document }
       #document(page-path-str, html.html(lang: lang, {
         import html: *
         head({
@@ -446,7 +450,7 @@
           meta(charset: "utf-8")
           meta(name: "viewport", content: "width=device-width, initial-scale=1")
           title(it.title)
-          link(rel: "canonical", href: canonical-url + page-path-str)
+          if page-url != none { link(rel: "canonical", href: page-url) }
           // TODO: finish description here
           meta(name: "description", content: "...")
           // Styles
@@ -457,29 +461,23 @@
           og-property("title", content: to-string("" + it.title))
           og-property("description", content: to-string("" + [...]))
           og-property("type", content: "website")
-          og-property("url", content: canonical-url + page-path-str)
+          if page-url != none { og-property("url", content: page-url) }
           og-property("site_name", content: site-title)
-          if type(summary-image-renderer) == function {
-            summary-image-renderer(it).og-properties
-          }
+          if summary-image != none { summary-image.og-properties }
           // Twitter SEO
           meta(name: "twitter:title", content: to-string("" + it.title))
-          meta(name: "twitter:domain", content: canonical-url.replace(regex("https?://"), ""))
+          if base-url != none {
+            meta(name: "twitter:domain", content: base-url.replace(regex("^\w+://"), "").split("/").first())
+          }
           meta(name: "twitter:description", content: "...")
           if pagefind-enabled {
-            let link-path = "/" + (root + ("pagefind", "pagefind-component-ui.css")).join("/")
-            let script-path = "/" + (root + ("pagefind", "pagefind-component-ui.js")).join("/")
+            let link-path = (up + ("pagefind", "pagefind-component-ui.css")).join("/")
+            let script-path = (up + ("pagefind", "pagefind-component-ui.js")).join("/")
             link(href: link-path, rel: "stylesheet")
-            script(src: script-path, type: "module")
+            script(src: script-path, defer: true)
           }
         })
         body(class: "dark:bg-zinc-900", {
-          if pagefind-enabled {
-            elem("pagefind-config", attrs: (
-              bundle-path: "/" + (root + ("pagefind",)).join("/") + "/",
-              base-url: "/",
-            ))
-          }
           internal-html-renderer(
             tree,
             it,
@@ -494,8 +492,8 @@
 }
 
 
-#let paged-renderer(tree, root: (), ..args) = [
-  #document(root.join("/") + "/doc.pdf", for it in flatten-tree(tree) {
+#let paged-renderer(tree, ..args) = [
+  #document("/doc.pdf", for it in flatten-tree(tree) {
     it.content
   }) <doc.pdf>
 ]

--- a/readme.typ
+++ b/readme.typ
@@ -39,18 +39,18 @@
 #let sample-text = ```typ
 #import "@preview/haita:__PACKAGE_VERSION__": * // Always remember to import the package
 #book(
-  // The routing root. Useful when you are deploying to a folder
-  // under your root (e.g. when deployed to GitHub Pages)
-  // root: "haita",
+  // Where the site will be deployed. Optional: it is only used for the
+  // SEO metadata, everything inside the site is linked relatively.
+  // base-url: "https://username.github.io/haita",
   // Your document's contents
   tree: (
     // You can add arbitrary content. The content will be displayed
     // in the summary, but will not generate html pages.
     [= Introduction],
-    // This will create haita/index.html. The content of the
+    // This will create index.html. The content of the
     // chapter will be from `doc/intro.typ`
     chapter("index", content: include "doc/intro.typ"),
-    // This will create haita/doc/tutorial.html. In this case,
+    // This will create doc/tutorial.html. In this case,
     // the content of the chapter is not explicitly stated, so it
     // looks into ./doc/tutorial.typ in the current workspace.
     chapter("doc/tutorial"),


### PR DESCRIPTION
Dropping `root` is an opinionated change. 
Please close this if it does not fit where you are taking Haita, and if it does, I would be glad to see it merged, or to rework any part of it first.

## Summary

`canonical-url` and `root` are merged into a single, optional `base-url`, so a project no longer has to know where it will be deployed to start writing.

Since every link and asset resolves relatively, `root` only ever nested the output directory. 
Pagefind was the one piece that needed an absolute path, but it finds its own bundle and the site root through `document.currentScript`(→[MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)), it is not meant to be loaded as a module script, where that property is `null`.
Loading it as a classic `defer` script lets it work this out on its own, so `<pagefind-config>` is gone.

`base-url` is therefore left to SEO metadata alone. 
Without it the canonical link, `og:url` and `twitter:domain` are dropped, and `og:image` falls back to a page-relative file name, so setting it is still worthwhile for a real deployment.

This may open the door to a `typst init` template later on, though I have not looked into it.

## Breaking changes

- `canonical-url: "https://<username>.github.io"` with `root: "<project name>"` becomes `base-url: "https://<username>.github.io/<project name>"`; both old settings are gone.
- Output is no longer nested under `root`: the directory you compile into is the site root itself, so paths that pointed one level deeper (`./dist/haita`) now point at `./dist`.
- Page labels lose the same prefix: `label("page:/haita/tutorial")` becomes `label("page:/tutorial")`.
- Pagefind is always run with `--output-subdir pagefind`, never `--output-subdir my-book/pagefind`.
- Summary image renderers no longer take a canonical URL argument; `base-url` reaches them on its own.