### PR TITLE
fix: load Ace theme and mode in the JS embedding example

### DIFF
--- a/docs/tutorial/integration.typ
+++ b/docs/tutorial/integration.typ
@@ -102,6 +102,7 @@ left hand side.
     // The editor is the Ace editor. See `https://ace.c9.io/` for detailsa
     let script-text = ```js
     import ace from "https://cdn.jsdelivr.net/npm/ace-builds@1/+esm";
+    ace.config.set("basePath", "https://cdn.jsdelivr.net/npm/ace-builds@1/src-noconflict/");
 
     var editor = ace.edit("editor");
     editor.setTheme("ace/theme/monokai");


### PR DESCRIPTION
The theme setting of Ace editor was trying to load `https://wensimehrp.github.io/haita/tutorial/theme-monokai.js`, resulting in a 404 error. (The mode setting had the same issue)

<img width="1583" height="301" alt="image" src="https://github.com/user-attachments/assets/b02d8d4f-87ee-4376-80f6-d5152d8e537b" />


<img width="2147" height="269" alt="image" src="https://github.com/user-attachments/assets/5c6eb5d5-a30a-41ef-8cb6-0c44ec25c70b" />


This can be resolved by setting the basePath, referencing "Configure dynamic loading of modes and themes" in the [official documentation](https://ace.c9.io/#nav=howto).

<img width="1342" height="302" alt="image" src="https://github.com/user-attachments/assets/7d40cd1b-9edb-4489-9a8a-978e97591365" />
