### PR TITLE
fix: break long words like URLs to prevent horizontal overflow

### DIFF
--- a/new-hamber.typ
+++ b/new-hamber.typ
@@ -290,6 +290,7 @@
         " prose-pre:rounded-none"
         " prose-a:decoration-1 prose-a:underline-offset-4"
         " prose-a:hover:decoration-3"
+        " prose-a:break-words"
       },
       data-pagefind-body: "",
     ),

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -26,3 +26,7 @@ figure > div > pre,
 figure > p {
     margin-bottom: 0.85em !important;
 }
+
+#haita-main-content {
+    overflow-wrap: break-word;
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -26,7 +26,3 @@ figure > div > pre,
 figure > p {
     margin-bottom: 0.85em !important;
 }
-
-#haita-main-content {
-    overflow-wrap: break-word;
-}


### PR DESCRIPTION
Long URLs do not wrap and overflow the viewport, causing an unwanted horizontal scroll on narrow screens (iPhone 15 Pro / Safari).

<img src="https://github.com/user-attachments/assets/c0fba6e4-a496-4aa6-85b1-62aa868ed110" width="200"/>

*Before*

This adds [`overflow-wrap: break-word`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/overflow-wrap) to the main content, letting the browser break a word mid-string when it has no break point and does not fit on a line by itself. Same approach as [mdBook](https://github.com/rust-lang/mdBook/blob/b90df240a318da0c59ec3efe6b75a58f63c6c459/crates/mdbook-html/front-end/css/general.css#L31) and [Material for MkDocs](https://github.com/squidfunk/mkdocs-material/blob/191285962d5a2c1aa1e5764e9979219268a164c3/src/templates/assets/stylesheets/main/_typeset.scss#L78).

<img src="https://github.com/user-attachments/assets/0a4ac173-a4db-453e-b8dd-b9b6f08ff51f" width="200"/>

*After*

Confirmed the overflow is gone on iPhone 15 Pro (Safari).
Sorry, I don't have an Android device, so I couldn't check it there.