### PR TITLE
fix: remove unnecessary horizontal scroll on math blocks

### DIFF
--- a/styles/math.css
+++ b/styles/math.css
@@ -4,5 +4,5 @@ math {
 
 math[display="block"] {
     font-size: large;
-    width: max-content;
+    white-space: nowrap;
 }


### PR DESCRIPTION
On Safari (iOS/iPadOS, and macOS too), `width: max-content` makes MathML's intrinsic width come out wider than the formula actually is, so even short equations end up scrollable.

<img src="https://github.com/user-attachments/assets/dc275921-33f0-4ff6-b8a7-e18874471db9" width="250"/>

*Before*

Replace it with `white-space: nowrap`, which prevents line breaking directly instead of relying on intrinsic sizing.

<img src="https://github.com/user-attachments/assets/ceb60078-7a28-4635-b3de-815482bd05c9" width="250"/>

*After*

Verified on Safari (iOS/iPadOS/macOS), Firefox on Windows, Edge on Windows (and Zen on NixOS): short equations have zero scroll, long equations do not wrap and remain scrollable.